### PR TITLE
Better column names

### DIFF
--- a/R/alevin-EC.R
+++ b/R/alevin-EC.R
@@ -29,9 +29,9 @@
 #' 
 #' @return A list with two elements. The first element `counts` is a sparse 
 #' count matrix with equivalence class identifiers in the rows and barcode 
-#' identifiers in the columns. The second element `tx2gene_matched` allows for 
-#' linking the equivalence class identifiers to their respective transcripts 
-#' and genes.
+#' identifiers followed by an underscore and a sample identifier in the columns. 
+#' The second element `tx2gene_matched` allows for linking the equivalence class
+#' identifiers to their respective transcripts and genes.
 #' 
 #' @section Details:
 #' The resulting count matrix uses equivalence class identifiers as rownames.
@@ -122,7 +122,7 @@ the same annotation for both.\n\n",txFromFile,"\n\n",txFromTable,
     RowIdx <- rep(RowIdx, times=times)
     
     ## wrangle columns
-    bc_id_to_name <- sample_list[[i]][[5]]
+    bc_id_to_name <- paste0(sample_list[[i]][[5]], "_", i)
     ColIdx <- sample_list[[i]][[2]]
     
     ## wrangle entries

--- a/R/salmon-EC.R
+++ b/R/salmon-EC.R
@@ -27,9 +27,10 @@
 #' @author Jeroen Gilis
 #' 
 #' @return A list with two elements. The first element `counts` is a sparse 
-#' count matrix with equivalence class identifiers in the rows. The second 
-#' element `tx2gene_matched` allows for linking those identifiers to their 
-#' respective transcripts and genes.
+#' count matrix with equivalence class identifiers in the rows. If multiple 
+#' paths are specified, the coulmns are in the same order as the paths. The 
+#' second element `tx2gene_matched` allows for linking those identifiers to
+#' their respective transcripts and genes.
 #' 
 #' @section Details:
 #' The resulting count matrix uses equivalence class identifiers as rownames.

--- a/R/salmon-EC.R
+++ b/R/salmon-EC.R
@@ -28,7 +28,7 @@
 #' 
 #' @return A list with two elements. The first element `counts` is a sparse 
 #' count matrix with equivalence class identifiers in the rows. If multiple 
-#' paths are specified, the coulmns are in the same order as the paths. The 
+#' paths are specified, the columns are in the same order as the paths. The 
 #' second element `tx2gene_matched` allows for linking those identifiers to
 #' their respective transcripts and genes.
 #' 


### PR DESCRIPTION
Hi Mike,

I've been working with equivalence classes again, and noticed that when multiple paths (multiple samples) are given to `alevinEC`, the column names are still just the cellular barcodes, which are (1) not necessarily unique across samples and (ii) do not directly tell to which sample the barcode belongs. So now I internally append *_i* to the barcodes, where *i* is the sample (path) number.

Note: I didn't bump date and version.

Kind regards,

Jeroen