### PR TITLE
Allow importing of gene names with underscores

### DIFF
--- a/R/helper-allelic.R
+++ b/R/helper-allelic.R
@@ -143,10 +143,10 @@ importAllelicCounts <- function(coldata, a1, a2,
   # gather transcript names for a1 and a2 alleles
   txp_nms_a1 <- grep(a1match, rownames(se), value=TRUE)
   stopifnot(length(txp_nms_a1) == ntxp)
-  txp_nms_a2 <- sub(paste0("_",a1),paste0("_",a2),txp_nms_a1)
+  txp_nms_a2 <- grep(a2match, rownames(se), value=TRUE)
   stopifnot(all(txp_nms_a2 %in% rownames(se)))
   stopifnot(length(txp_nms_a1) == length(txp_nms_a2))
-  txp_nms <- sub(paste0("_",a1),"",txp_nms_a1)
+  txp_nms <- sapply(sapply(strsplit(txp_nms_a1, split = "_"), head, -1), paste, collapse='_')
   
   if (format == "wide") {
     coldata_wide <- data.frame(

--- a/R/helper-allelic.R
+++ b/R/helper-allelic.R
@@ -146,7 +146,12 @@ importAllelicCounts <- function(coldata, a1, a2,
   txp_nms_a2 <- grep(a2match, rownames(se), value=TRUE)
   stopifnot(all(txp_nms_a2 %in% rownames(se)))
   stopifnot(length(txp_nms_a1) == length(txp_nms_a2))
-  txp_nms <- sapply(sapply(strsplit(txp_nms_a1, split = "_"), head, -1), paste, collapse='_')
+  txp_nms <- strsplit(txp_nms_a1, split = "_")
+  txp_nms <- sapply(txp_nms, function(x){
+                                if ((length(x)>1) & (tail(x, 1) %in% c(a1, a2))) { 
+                                  x = head(x, -1)}
+                                x = paste(x, collapse='_')
+                                })
   
   if (format == "wide") {
     coldata_wide <- data.frame(


### PR DESCRIPTION
While trying to use this excellent tool on a project of mine that has a customized transcriptome, I encountered an error when using the a1/a2 suffixes, 'L' and 'R' (the default suffixes for g2gtools). 

Some of my gene names are of the format "XXX_LYYY" or "XXX_RYY". Removing the suffixes from the gene results in everything after the first _L or _R being deleted, which caused errors with importing salmon results.

I've made two small changes to the import code to ensure that only text after the last '_' is removed. This solves the issue on my end.