### PR TITLE
Fix bug salmonEC: internally address indexing discrepancy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fishpond
 Title: Fishpond: downstream methods and tools for expression data
-Version: 2.5.2
+Version: 2.5.3
 Authors@R: c(
     person("Anqi", "Zhu", role=c("aut","ctb")),
     person("Michael", "Love", email="michaelisaiahlove@gmail.com", role=c("aut","cre")),
@@ -40,4 +40,4 @@ biocViews: Sequencing, RNASeq, GeneExpression,
     AlternativeSplicing, SingleCell
 VignetteBuilder: knitr
 LazyData: true
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# fishpond 2.5.3
+
+* Fix bug where salmonEC did not correct equivalence class
+  names for going from 0-indexing to 1-indexing internally. In prior  
+  versions, to correctly link equivalence classes to gene names,
+  users would have needed to manually add a value of 1 to the 
+  equivalence class names, which was erroneously not mentioned
+  in the man files. After this bug fix, if the equivalence class 
+  identifier reads 1|2|8, then the equivalence class is immediatly 
+  compatible with the transcripts and their respective genes in rows
+  1, 2 and 8 of 'tx2gene_matched', without any further user 
+  intervention.
+
 # fishpond 2.5.1
 
 * Fix plotAllelicGene() so that when samples have an allele

--- a/R/salmon-EC.R
+++ b/R/salmon-EC.R
@@ -46,7 +46,7 @@ salmonEC <- function(paths, tx2gene, multigene = FALSE, ignoreTxVersion = FALSE,
                       ignoreAfterBar = FALSE, quiet = FALSE){
   
   if (!requireNamespace("data.table", quietly=TRUE)) {
-    stop("alevinEC() requires CRAN package data.table")
+    stop("salmonEC() requires CRAN package data.table")
   }
   
   if(!all(file.exists(paths))){
@@ -152,16 +152,16 @@ readEq <- function(file, geneSet, startread, multigene){
   eccs <- strsplit(ec_df$V1,"\t",fixed=TRUE)
   
   # remove first and last -> keep ECCs and not their corresponding TXs and counts
-  eccs_hlp <- lapply(eccs, function(x) x[-c(1,length(x))])
+  eccs_hlp <- lapply(eccs, function(x) as.integer(x[-c(1, length(x))])+1)
+  # +1 to account for going from 0-indexing to 1-indexing
   
   if(!multigene){ # remove ECs corresponding to multiple genes
     hlp <- unlist(lapply(eccs_hlp, function(element) {
-      gene_cur <- geneSet[as.integer(element)+1]
-      # if annotation not complete -> remove EC with any NA genes
-      if(any(is.na(gene_cur))){ 
+      if (any(is.na(geneSet[element]))) {
         return(TRUE)
-      } else{
-        return(length(unique(gene_cur))!=1)
+      }
+      else {
+        return(length(unique(geneSet[element])) != 1)
       }
     }))
     eccs_hlp[hlp] <- NULL

--- a/tests/testthat/test_salmonEC.R
+++ b/tests/testthat/test_salmonEC.R
@@ -44,6 +44,14 @@ test_that("Importing transcript compatibility counts from salmon output works",{
     # test rownames type
     expect_true(is(rownames(EC_mat$counts), "character"))
     
+    # test multigene = FALSE and equivalence class to gene matching
+    eccs <- strsplit(rownames(EC_mat$counts),"\\|",fixed=FALSE)
+    nrGeneForEachEcc <- unlist(lapply(eccs, function(ecc){
+      length(unique(EC_mat$tx2gene_matched$gene_id[as.integer(ecc)]))
+    }))
+    # each ecc must only be compatible with a single gene if multigene = FALSE
+    expect_true(all(nrGeneForEachEcc == 1))
+    
     if (slow) {
       # test quiet argument
       expect_silent(salmonEC(paths = files,


### PR DESCRIPTION
Fix bug where salmonEC did not correct equivalence class names for going from 0-indexing to 1-indexing internally. In prior versions, to correctly link equivalence classes to gene names, users would have needed to manually add a value of 1 to the equivalence class names, which was erroneously not mentioned in the man files. After this bug fix, if the equivalence class 
identifier reads 1|2|8, then the equivalence class is immediately compatible with the transcripts and their respective genes in rows 1, 2 and 8 of 'tx2gene_matched', without any further user  intervention.